### PR TITLE
also required oauth2

### DIFF
--- a/Python_Requirements/requirements.txt
+++ b/Python_Requirements/requirements.txt
@@ -2,3 +2,4 @@ tornado
 celery
 us
 requests
+oauth2 // pip install oauth2 (note: not 'python-oauth2')


### PR DESCRIPTION
I tried 'pip install python-oauth2', but got 'oauth2 has no attribute named Consumer' error.

Fixed by:
$pip uninstall python-oauth2
$pip install oauth2